### PR TITLE
Validate required columns in uploaded datasets

### DIFF
--- a/app.py
+++ b/app.py
@@ -179,13 +179,20 @@ if not (orig_file and tgt_file):
     st.info("⬆️ Carica **Lista di Origine** e **Lista di Confronto** per iniziare.")
     st.stop()
 
-# Carica
-df_orig = load_data(orig_file)
-df_tgt  = load_data(tgt_file)
+# Colonne richieste
+required_columns = ["ASIN", "Locale", origin_price_col, target_price_col]
 
-# Merge by ASIN (safe)
-if "ASIN" not in df_orig.columns or "ASIN" not in df_tgt.columns:
-    st.error("Assicurati che entrambi i file contengano la colonna **ASIN**.")
+# Carica e verifica colonne
+df_orig = load_data(orig_file)
+missing = [c for c in required_columns if c not in df_orig.columns]
+if missing:
+    st.error(f"Lista di Origine: mancano le colonne {', '.join(missing)}")
+    st.stop()
+
+df_tgt = load_data(tgt_file)
+missing = [c for c in required_columns if c not in df_tgt.columns]
+if missing:
+    st.error(f"Lista di Confronto: mancano le colonne {', '.join(missing)}")
     st.stop()
 
 # Left join: partiamo dall'origine (identità/Locale/peso), poi aggiungiamo target


### PR DESCRIPTION
## Summary
- Ensure both uploaded datasets contain required columns: ASIN, Locale, and selected price columns
- Stop execution with a clear error message when any required column is missing

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'load_keepa' from 'loaders')*

------
https://chatgpt.com/codex/tasks/task_e_689e936478048320be131f5d4425fd94