### PR TITLE
refactor: centralize numeric parsing

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,7 +37,7 @@ def _safe(x):
                 return "—"
             return f"{x:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
         # tenta conversione numerica soft
-        xv = pd.to_numeric(pd.Series([x]), errors="coerce").iloc[0]
+        xv = parse_float(x, default=np.nan)
         if pd.notna(xv):
             return _safe(float(xv))
         return str(x)
@@ -122,13 +122,10 @@ target_price_col = st.sidebar.selectbox("Prezzo Target (Amazon)", options=price_
 
 st.sidebar.subheader("Parametri vendita")
 use_fba = st.sidebar.toggle("Usa FBA (considera Pick&Pack)", value=False)
-site_price_override = st.sidebar.text_input("Prezzo HDGaming (vuoto = usa BB IT Current)", value="")
-site_price_override_val = None
-if site_price_override.strip() != "":
-    try:
-        site_price_override_val = float(str(site_price_override).replace(",", "."))
-    except Exception:
-        site_price_override_val = None  # fallback: usa default
+site_price_override = st.sidebar.text_input(
+    "Prezzo HDGaming (vuoto = usa BB IT Current)", value=""
+)
+site_price_override_val = parse_float(site_price_override, default=None)
 
 st.sidebar.subheader("Sconto acquisto (default 21%)")
 disc_default = st.sidebar.slider("Sconto default per tutti i paesi", min_value=0, max_value=60, value=21, step=1) / 100.0
@@ -227,14 +224,34 @@ def _to_pct(x):
 df_view = dfp.copy()
 df_view["ProfitAmazonPctView"] = df_view["ProfitAmazonPct"].map(_to_pct)
 df_view["ProfitSitePctView"] = df_view["ProfitSitePct"].map(_to_pct)
-df_view["BB_AmzShare90d"] = pd.to_numeric(dfp.get("Buy Box: % Amazon 90 days", pd.Series([np.nan]*len(dfp))), errors="coerce")
+df_view["BB_AmzShare90d"] = (
+    dfp.get("Buy Box: % Amazon 90 days", pd.Series([np.nan] * len(dfp)))
+    .map(lambda x: parse_float(x, default=np.nan))
+    .astype(float)
+)
 
 mask = (
-    (pd.to_numeric(df_view["ProfitAmazonEUR"], errors="coerce").fillna(-9e9) >= float(min_profit_eur)) &
-    (pd.to_numeric(df_view["ProfitAmazonPctView"], errors="coerce").fillna(-9e9) >= float(min_profit_pct)) &
-    (df_view["BB_AmzShare90d"].fillna(0.0) <= float(max_amz_share)) &
-    (pd.to_numeric(df_view.get("Total Offer Count", pd.Series([0]*len(df_view))), errors="coerce").fillna(0) <= int(max_offer_cnt)) &
-    (pd.to_numeric(df_view.get("Sales Rank: Current", pd.Series([0]*len(df_view))), errors="coerce").fillna(0) <= int(max_rank))
+    (
+        df_view["ProfitAmazonEUR"].map(lambda x: parse_float(x, default=np.nan)).fillna(-9e9)
+        >= float(min_profit_eur)
+    )
+    & (
+        df_view["ProfitAmazonPctView"].map(lambda x: parse_float(x, default=np.nan)).fillna(-9e9)
+        >= float(min_profit_pct)
+    )
+    & (df_view["BB_AmzShare90d"].fillna(0.0) <= float(max_amz_share))
+    & (
+        df_view.get("Total Offer Count", pd.Series([0] * len(df_view)))
+        .map(lambda x: parse_int(x, default=np.nan))
+        .fillna(0)
+        <= int(max_offer_cnt)
+    )
+    & (
+        df_view.get("Sales Rank: Current", pd.Series([0] * len(df_view)))
+        .map(lambda x: parse_int(x, default=np.nan))
+        .fillna(0)
+        <= int(max_rank)
+    )
 )
 df_view = df_view[mask]
 

--- a/score.py
+++ b/score.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import math
 import pandas as pd
 import numpy as np
-from loaders import parse_float
+from loaders import parse_float, parse_int, parse_weight
 
 # ---------------------------
 # Config base & costanti
@@ -65,7 +65,7 @@ def _col(df: pd.DataFrame, name: str, default=0.0) -> pd.Series:
 def _norm_percentile(series: pd.Series, low=0.05, high=0.95):
     if series is None or len(series) == 0:
         return pd.Series([], dtype=float)
-    s = pd.to_numeric(series, errors="coerce").replace([np.inf, -np.inf], np.nan)
+    s = series.map(lambda x: parse_float(x, default=np.nan)).replace([np.inf, -np.inf], np.nan)
     fill = np.nanmedian(s) if np.isfinite(np.nanmedian(s)) else 0.0
     s = s.fillna(fill)
     a, b = np.nanquantile(s, low), np.nanquantile(s, high)
@@ -76,9 +76,9 @@ def _norm_percentile(series: pd.Series, low=0.05, high=0.95):
 
 def _zscore(x: pd.Series, mean: pd.Series, std: pd.Series) -> pd.Series:
     """Z = (x - mean) / std, con gestione std=0 e non finiti."""
-    x = pd.to_numeric(x, errors="coerce")
-    mean = pd.to_numeric(mean, errors="coerce")
-    std = pd.to_numeric(std, errors="coerce")
+    x = x.map(lambda v: parse_float(v, default=np.nan))
+    mean = mean.map(lambda v: parse_float(v, default=np.nan))
+    std = std.map(lambda v: parse_float(v, default=np.nan))
     std_safe = std.where(std.abs() > 1e-12, np.nan)
     z = (x - mean) / std_safe
     z = z.where(np.isfinite(z), 0.0)
@@ -94,7 +94,7 @@ def _to_bool_series(s: pd.Series) -> pd.Series:
     if s is None or len(s) == 0:
         return pd.Series([], dtype=bool)
     # prova numerico
-    s_num = pd.to_numeric(s, errors="coerce")
+    s_num = s.map(lambda v: parse_float(v, default=np.nan))
     mask_num = s_num.notna()
     out = pd.Series(False, index=s.index)
     out.loc[mask_num] = s_num.loc[mask_num] > 0
@@ -134,7 +134,7 @@ def calc_final_purchase_price(
             discount_map = {}
         default_disc = float(discount_map.get("discount_default_all", 0.21))
 
-        prices = pd.to_numeric(_col(df, price_col_origin), errors="coerce")
+        prices = _col(df, price_col_origin).map(lambda x: parse_float(x, default=np.nan))
         locales = _col(df, origin_locale_col).astype(str).map(normalize_locale)
 
         out = []
@@ -195,27 +195,32 @@ def compute_profits(
     vat_target = VAT_RATES.get(normalize_locale(locale_target), 0.22)
     vat_it = VAT_RATES.get("IT", 0.22)
 
-    sale_gross_amz = pd.to_numeric(_col(df, price_col_target_bb), errors="coerce")
+    sale_gross_amz = _col(df, price_col_target_bb).map(lambda x: parse_float(x, default=np.nan))
 
-    fee_ref_amt = pd.to_numeric(_col(df, "Referral Fee based on current Buy Box price", np.nan), errors="coerce")
-    fee_ref_pct = pd.to_numeric(_col(df, "Referral Fee %", 0.0), errors="coerce") / 100.0
+    fee_ref_amt = _col(df, "Referral Fee based on current Buy Box price", np.nan).map(lambda x: parse_float(x, default=np.nan))
+    fee_ref_pct = _col(df, "Referral Fee %", 0.0).map(lambda x: parse_float(x, default=np.nan)) / 100.0
     fee_ref_amt = fee_ref_amt.fillna(fee_ref_pct * sale_gross_amz)
 
-    weights = pd.to_numeric(_col(df, "Package: Weight (g)", np.nan), errors="coerce")
-    weights = weights.fillna(pd.to_numeric(_col(df, "Item: Weight (g)", 0.0), errors="coerce"))
+    pkg_w = _col(df, "Package: Weight (g)", np.nan).map(lambda x: parse_weight(x) if pd.notna(x) else np.nan)
+    item_w = _col(df, "Item: Weight (g)", np.nan).map(lambda x: parse_weight(x) if pd.notna(x) else np.nan)
+    weights = pkg_w.fillna(item_w).fillna(0.0)
     ship_fbm = weights.map(calculate_shipping_cost)
 
-    pick_pack = pd.to_numeric(_col(df, "FBA Pick&Pack Fee", 0.0), errors="coerce") if use_fba else pd.Series([0.0]*len(df), index=df.index)
+    pick_pack = (
+        _col(df, "FBA Pick&Pack Fee", 0.0).map(lambda x: parse_float(x, default=np.nan))
+        if use_fba
+        else pd.Series([0.0] * len(df), index=df.index)
+    )
     ship_out_eff = pd.Series([0.0]*len(df), index=df.index) if use_fba else ship_fbm
 
     proceeds_gross_amz = sale_gross_amz - fee_ref_amt - pick_pack - ship_out_eff
     proceeds_exvat_amz = proceeds_gross_amz / (1.0 + vat_target)
 
-    purchase_net = pd.to_numeric(df["PurchaseNetExVAT"], errors="coerce")
+    purchase_net = df["PurchaseNetExVAT"].map(lambda x: parse_float(x, default=np.nan))
     profit_amz_eur = proceeds_exvat_amz - purchase_net
     profit_amz_pct = profit_amz_eur / purchase_net.replace(0, np.nan)
 
-    default_site_price = pd.to_numeric(_col(df, "Buy Box 🚚: Current", np.nan), errors="coerce")
+    default_site_price = _col(df, "Buy Box 🚚: Current", np.nan).map(lambda x: parse_float(x, default=np.nan))
     site_price_series = pd.Series([site_price]*len(df), index=df.index) if site_price is not None else default_site_price
 
     pay_fee = site_price_series * float(payment_fee_site)
@@ -241,28 +246,28 @@ def compute_profits(
 
 def margin_score(df: pd.DataFrame) -> pd.Series:
     """Basic margin-based score normalised to 0–1."""
-    margin = pd.to_numeric(_col(df, "Margine_Netto_%", 0.0), errors="coerce")
-    bonus = pd.to_numeric(_col(df, "Trend_Bonus", 0.0), errors="coerce")
-    roi = pd.to_numeric(_col(df, "ROI_Factor", 0.0), errors="coerce")
+    margin = _col(df, "Margine_Netto_%", 0.0).map(lambda x: parse_float(x, default=np.nan))
+    bonus = _col(df, "Trend_Bonus", 0.0).map(lambda x: parse_float(x, default=np.nan))
+    roi = _col(df, "ROI_Factor", 0.0).map(lambda x: parse_float(x, default=np.nan))
     combined = margin.fillna(0) + bonus.fillna(0) + roi.fillna(0)
     return _norm_percentile(combined)
 
 
 def demand_score(df: pd.DataFrame) -> pd.Series:
     """Higher score for lower sales rank."""
-    rank = pd.to_numeric(_col(df, "SalesRank_Comp", np.nan), errors="coerce")
+    rank = _col(df, "SalesRank_Comp", np.nan).map(lambda x: parse_int(x, default=np.nan))
     return (1.0 - _norm_percentile(rank.fillna(rank.median()))).clip(0, 1)
 
 
 def competition_score(df: pd.DataFrame) -> pd.Series:
     """Higher score when there are fewer competing offers."""
-    offers = pd.to_numeric(_col(df, "NewOffer_Comp", np.nan), errors="coerce")
+    offers = _col(df, "NewOffer_Comp", np.nan).map(lambda x: parse_int(x, default=np.nan))
     return (1.0 - _norm_percentile(offers.fillna(offers.median()))).clip(0, 1)
 
 
 def volatility_score(df: pd.DataFrame) -> pd.Series:
     """Score inversely related to price volatility."""
-    vol = pd.to_numeric(_col(df, "PriceVolatility", 0.0), errors="coerce")
+    vol = _col(df, "PriceVolatility", 0.0).map(lambda x: parse_float(x, default=np.nan))
     return (1.0 - _norm_percentile(vol)).clip(0, 1)
 
 
@@ -300,8 +305,12 @@ def compute_opportunity_score(
     weights_core keys: Epsilon,Theta,Alpha,Beta,Delta,Zeta,Gamma
     """
     # ------ Profit component (Epsilon/Theta) ------
-    nz_profit_pct = _norm_percentile(pd.to_numeric(_col(df, "ProfitAmazonPct", 0.0), errors="coerce").fillna(0.0))
-    nz_profit_eur = _norm_percentile(pd.to_numeric(_col(df, "ProfitAmazonEUR", 0.0), errors="coerce").fillna(0.0))
+    nz_profit_pct = _norm_percentile(
+        _col(df, "ProfitAmazonPct", 0.0).map(lambda x: parse_float(x, default=np.nan)).fillna(0.0)
+    )
+    nz_profit_eur = _norm_percentile(
+        _col(df, "ProfitAmazonEUR", 0.0).map(lambda x: parse_float(x, default=np.nan)).fillna(0.0)
+    )
     eps = float(weights_core.get("Epsilon", 3.0))
     the = float(weights_core.get("Theta", 1.5))
     denom = max(1e-6, eps + the)
@@ -309,9 +318,9 @@ def compute_opportunity_score(
     profit_component = profit_component.clip(0, 1)
 
     # ------ Kappa (MarketEdge) ------
-    bb_cur   = pd.to_numeric(_col(df, "SaleGrossAmazon", 0.0), errors="coerce")
-    bb90_tgt = pd.to_numeric(_col(df, "Buy Box 🚚: 90 days avg.", bb_cur), errors="coerce")
-    sd90_tgt = pd.to_numeric(_col(df, "Buy Box: Standard Deviation 90 days", 0.0), errors="coerce")
+    bb_cur   = _col(df, "SaleGrossAmazon", 0.0).map(lambda x: parse_float(x, default=np.nan))
+    bb90_tgt = _col(df, "Buy Box 🚚: 90 days avg.", bb_cur).map(lambda x: parse_float(x, default=np.nan))
+    sd90_tgt = _col(df, "Buy Box: Standard Deviation 90 days", 0.0).map(lambda x: parse_float(x, default=np.nan))
     sd90_tgt = sd90_tgt.where(sd90_tgt.abs() > 1e-9, np.nan)
 
     z_sell_raw = _zscore(bb_cur, bb90_tgt, sd90_tgt)
@@ -319,10 +328,10 @@ def compute_opportunity_score(
 
     origin_locale = _col(df, "Locale", "IT").astype(str).map(normalize_locale)
     vat_origin_series = origin_locale.map(lambda c: VAT_RATES.get(c, 0.22))
-    buy_gross_proxy = pd.to_numeric(_col(df, "PurchaseNetExVAT", 0.0), errors="coerce") * (1.0 + vat_origin_series)
+    buy_gross_proxy = _col(df, "PurchaseNetExVAT", 0.0).map(lambda x: parse_float(x, default=np.nan)) * (1.0 + vat_origin_series)
 
-    bb90_orig = pd.to_numeric(_col(df, "Buy Box 🚚: 90 days avg. (origine)", bb90_tgt), errors="coerce")
-    sd90_orig = pd.to_numeric(_col(df, "Buy Box: Standard Deviation 90 days (origine)", sd90_tgt), errors="coerce")
+    bb90_orig = _col(df, "Buy Box 🚚: 90 days avg. (origine)", bb90_tgt).map(lambda x: parse_float(x, default=np.nan))
+    sd90_orig = _col(df, "Buy Box: Standard Deviation 90 days (origine)", sd90_tgt).map(lambda x: parse_float(x, default=np.nan))
     sd90_orig = sd90_orig.where(sd90_orig.abs() > 1e-9, np.nan)
 
     z_buy_raw = _zscore(buy_gross_proxy, bb90_orig, sd90_orig)
@@ -330,46 +339,46 @@ def compute_opportunity_score(
 
     edge_base = (z_sell + (1.0 - z_buy)) / 2.0  # 0–1
 
-    thr = pd.to_numeric(_col(df, "Competitive Price Threshold", np.nan), errors="coerce")
-    sug = pd.to_numeric(_col(df, "Suggested Lower Price", np.nan), errors="coerce")
+    thr = _col(df, "Competitive Price Threshold", np.nan).map(lambda x: parse_float(x, default=np.nan))
+    sug = _col(df, "Suggested Lower Price", np.nan).map(lambda x: parse_float(x, default=np.nan))
     pen_thr = _to_bool_series(bb_cur > thr).astype(float) * 0.15
     pen_sug = _to_bool_series(bb_cur > sug).astype(float) * 0.10
 
     kappa = (edge_base - pen_thr - pen_sug).clip(0, 1)
 
     # ------ Nu (DemandMomentum) ------
-    rank_curr = pd.to_numeric(_col(df, "Sales Rank: Current", np.nan), errors="coerce")
+    rank_curr = _col(df, "Sales Rank: Current", np.nan).map(lambda x: parse_int(x, default=np.nan))
     rank_score = 1.0 - _norm_percentile(rank_curr.fillna(np.nanmedian(rank_curr)))
-    drops90 = _norm_percentile(pd.to_numeric(_col(df, "Sales Rank: Drops last 90 days", 0.0), errors="coerce"))
-    bpm     = _norm_percentile(pd.to_numeric(_col(df, "Bought in past month", 0.0), errors="coerce"))
-    chg90   = _norm_percentile(pd.to_numeric(_col(df, "90 days change % monthly sold", 0.0), errors="coerce"))
+    drops90 = _norm_percentile(_col(df, "Sales Rank: Drops last 90 days", 0.0).map(lambda x: parse_int(x, default=np.nan)))
+    bpm     = _norm_percentile(_col(df, "Bought in past month", 0.0).map(lambda x: parse_int(x, default=np.nan)))
+    chg90   = _norm_percentile(_col(df, "90 days change % monthly sold", 0.0).map(lambda x: parse_float(x, default=np.nan)))
     zeta    = float(weights_core.get("Zeta", 1.0))
     nu = (0.40*rank_score + 0.25*drops90 + 0.20*bpm + 0.15*chg90 + 0.05*(zeta/3.0)).clip(0,1)
 
     # ------ Xi (CompetitionPressure) ------
-    offer   = _norm_percentile(pd.to_numeric(_col(df, "Total Offer Count", 0.0), errors="coerce"))
-    winner  = 1.0 - _norm_percentile(pd.to_numeric(_col(df, "Buy Box: Winner Count 90 days", 0.0), errors="coerce"))
-    unqual  = _norm_percentile(pd.to_numeric(_col(df, "Buy Box: Unqualified", 0.0), errors="coerce"))
+    offer   = _norm_percentile(_col(df, "Total Offer Count", 0.0).map(lambda x: parse_int(x, default=np.nan)))
+    winner  = 1.0 - _norm_percentile(_col(df, "Buy Box: Winner Count 90 days", 0.0).map(lambda x: parse_int(x, default=np.nan)))
+    unqual  = _norm_percentile(_col(df, "Buy Box: Unqualified", 0.0).map(lambda x: parse_int(x, default=np.nan)))
     map_pen = _to_bool_series(_col(df, "MAP restriction", False)).astype(float) * 0.2
     xi = (1.0 - (0.5*offer + 0.3*winner) + 0.2*unqual - map_pen).clip(0,1)
 
     # ------ Mu (AmazonRisk) ------
-    p_amz = _norm_percentile(pd.to_numeric(_col(df, "Buy Box: % Amazon 90 days", 0.0), errors="coerce"))
-    oos   = _norm_percentile(pd.to_numeric(_col(df, "Amazon: OOS Count 90 days", 0.0), errors="coerce"))
+    p_amz = _norm_percentile(_col(df, "Buy Box: % Amazon 90 days", 0.0).map(lambda x: parse_float(x, default=np.nan)))
+    oos   = _norm_percentile(_col(df, "Amazon: OOS Count 90 days", 0.0).map(lambda x: parse_int(x, default=np.nan)))
     delay_presence = _to_bool_series(_col(df, "Amazon: Amazon offer shipping delay", np.nan)).astype(float) * 0.1
     mu = (1.0 - 0.8*p_amz + 0.3*oos + delay_presence).clip(0,1)
 
     # ------ Lambda (PriceStability) ------
-    sd90_for_stab = _norm_percentile(pd.to_numeric(_col(df, "Buy Box: Standard Deviation 90 days", 0.0), errors="coerce"))
-    flp           = _norm_percentile(pd.to_numeric(_col(df, "Buy Box: Flipability 90 days", 0.0), errors="coerce"))
+    sd90_for_stab = _norm_percentile(_col(df, "Buy Box: Standard Deviation 90 days", 0.0).map(lambda x: parse_float(x, default=np.nan)))
+    flp           = _norm_percentile(_col(df, "Buy Box: Flipability 90 days", 0.0).map(lambda x: parse_float(x, default=np.nan)))
     lamb = (1.0 - 0.7*sd90_for_stab + 0.5*flp).clip(0,1)
 
     # ------ Rho (QualityRisk) ------
-    ret   = 1.0 - _norm_percentile(pd.to_numeric(_col(df, "Return Rate", 0.0), errors="coerce"))
-    rate  = _norm_percentile(pd.to_numeric(_col(df, "Reviews: Rating", 0.0), errors="coerce"))
+    ret   = 1.0 - _norm_percentile(_col(df, "Return Rate", 0.0).map(lambda x: parse_float(x, default=np.nan)))
+    rate  = _norm_percentile(_col(df, "Reviews: Rating", 0.0).map(lambda x: parse_float(x, default=np.nan)))
     rc_g  = _norm_percentile(
-        pd.to_numeric(_col(df, "Reviews: Rating Count", 0.0), errors="coerce") -
-        pd.to_numeric(_col(df, "Reviews: Rating Count - 90 days avg.", 0.0), errors="coerce")
+        _col(df, "Reviews: Rating Count", 0.0).map(lambda x: parse_int(x, default=np.nan)) -
+        _col(df, "Reviews: Rating Count - 90 days avg.", 0.0).map(lambda x: parse_int(x, default=np.nan))
     )
     deal_pen = _to_bool_series(_col(df, "Lightning Deals: Is Lowest", False)).astype(float) * 0.1
     rho = (0.5*ret + 0.3*rate + 0.2*rc_g - deal_pen).clip(0,1)


### PR DESCRIPTION
## Summary
- replace scattered `pd.to_numeric` calls in the app with `parse_float` and `parse_int`
- use parsing helpers in scoring logic and when reading weight columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e9657c308832089578f9015509a05