### PR TITLE
Add price regime analysis and ASIN detail view

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ from loaders import load_data, parse_float, parse_int, parse_weight, default_dis
 from score import (
     SHIPPING_COSTS, VAT_RATES, normalize_locale,
     calculate_shipping_cost, calc_final_purchase_price,
-    compute_profits, compute_opportunity_score
+    compute_profits, compute_opportunity_score, compute_price_regime
 )
 
 # -----------------------
@@ -64,6 +64,22 @@ def _badge(value, suffix="€"):
             txt = disp
         except Exception:
             cls = "badge-profit-neu"; txt = "—"
+    return f'<span class="badge badge-xl {cls}">{txt}</span>'
+
+def _z_badge(z):
+    """Badge colorato per z-score: verde ≤ -1, rosso ≥ 1, grigio altrimenti."""
+    try:
+        v = float(z)
+    except Exception:
+        return f'<span class="badge badge-xl badge-profit-neu">—</span>'
+    if np.isnan(v):
+        return f'<span class="badge badge-xl badge-profit-neu">—</span>'
+    cls = "badge-profit-neu"
+    if v <= -1:
+        cls = "badge-profit-pos"
+    elif v >= 1:
+        cls = "badge-profit-neg"
+    txt = f"{v:.2f}"
     return f'<span class="badge badge-xl {cls}">{txt}</span>'
 
 
@@ -352,6 +368,20 @@ html_table = f"""
 </div>
 """
 st.markdown(html_table, unsafe_allow_html=True)
+
+# Dettaglio per ASIN selezionato
+asin_sel = st.selectbox("Dettaglio ASIN", options=df_ess["ASIN"].unique())
+df_sel = dfp[dfp["ASIN"] == asin_sel]
+reg = compute_price_regime(df_sel, target_price_col)
+with st.expander("Price Regime"):
+    st.write("Media 30g:", _safe(reg.get("BB_MA_30")))
+    st.write("Media 90g:", _safe(reg.get("BB_MA_90")))
+    st.write("Media 180g:", _safe(reg.get("BB_MA_180")))
+    st.write("Media 365g:", _safe(reg.get("BB_MA_365")))
+    st.write("Deviazione std:", _safe(reg.get("BB_STD")))
+    st.write("Banda -1σ:", _safe(reg.get("BB_LOWER_1SD")))
+    st.write("Banda +1σ:", _safe(reg.get("BB_UPPER_1SD")))
+    st.markdown("Z-score attuale: " + _z_badge(reg.get("BB_ZSCORE")), unsafe_allow_html=True)
 
 # Pannello avanzato opzionale
 with st.expander("Dettagli avanzati / diagnostica"):

--- a/score.py
+++ b/score.py
@@ -109,6 +109,66 @@ def _to_bool_series(s: pd.Series) -> pd.Series:
     return out
 
 # ---------------------------
+# Price regime helpers
+# ---------------------------
+
+def compute_price_regime(df: pd.DataFrame, price_col: str) -> pd.Series:
+    """Calcola medie mobili e regime di prezzo per una serie Buy Box.
+
+    Restituisce una ``Series`` con:
+      - medie 30/90/180/365 giorni
+      - deviazione standard (ultimi 365 giorni)
+      - bande ``±1σ`` attorno alla media 365
+      - z-score dell'ultimo prezzo rispetto alla media 365
+    """
+
+    prices = _col(df, price_col).map(lambda x: parse_float(x, default=np.nan))
+    prices = prices.dropna()
+    if prices.empty:
+        return pd.Series(
+            {
+                "BB_MA_30": np.nan,
+                "BB_MA_90": np.nan,
+                "BB_MA_180": np.nan,
+                "BB_MA_365": np.nan,
+                "BB_STD": np.nan,
+                "BB_LOWER_1SD": np.nan,
+                "BB_UPPER_1SD": np.nan,
+                "BB_ZSCORE": np.nan,
+            }
+        )
+
+    def _mean(window: int) -> float:
+        if len(prices) < window:
+            return prices.mean()
+        return prices.tail(window).mean()
+
+    ma30 = _mean(30)
+    ma90 = _mean(90)
+    ma180 = _mean(180)
+    ma365 = _mean(365)
+
+    segment = prices.tail(min(365, len(prices)))
+    std = segment.std()
+    lower = ma365 - std if pd.notna(std) else np.nan
+    upper = ma365 + std if pd.notna(std) else np.nan
+    current = prices.iloc[-1]
+    z = (current - ma365) / std if pd.notna(std) and std > 1e-12 else 0.0
+
+    return pd.Series(
+        {
+            "BB_MA_30": ma30,
+            "BB_MA_90": ma90,
+            "BB_MA_180": ma180,
+            "BB_MA_365": ma365,
+            "BB_STD": std,
+            "BB_LOWER_1SD": lower,
+            "BB_UPPER_1SD": upper,
+            "BB_ZSCORE": z,
+        }
+    )
+
+# ---------------------------
 # Logica costo d’acquisto (invariata, default sconto 21%)
 # ---------------------------
 

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -4,10 +4,12 @@ import sys
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 import pandas as pd
+import pytest
 from score import (
     compute_profits,
     compute_opportunity_score,
     aggregate_opportunities,
+    compute_price_regime,
 )
 
 
@@ -39,3 +41,17 @@ def test_aggregate_opportunities():
     a1 = agg[agg["ASIN"] == "A1"].iloc[0]
     assert a1["Opportunity_Score"] == 20
     assert a1["Best_Market"] == "FR"
+
+
+def test_compute_price_regime_basic():
+    df = pd.DataFrame({"bb": range(1, 101)})
+    reg = compute_price_regime(df, "bb")
+    assert reg["BB_MA_30"] == pytest.approx(df["bb"].tail(30).mean())
+    assert reg["BB_MA_90"] == pytest.approx(df["bb"].tail(90).mean())
+    assert reg["BB_MA_180"] == pytest.approx(df["bb"].mean())
+    assert reg["BB_MA_365"] == pytest.approx(df["bb"].mean())
+    exp_std = df["bb"].std()
+    assert reg["BB_STD"] == pytest.approx(exp_std)
+    current = df["bb"].iloc[-1]
+    z = (current - reg["BB_MA_365"]) / exp_std
+    assert reg["BB_ZSCORE"] == pytest.approx(z)


### PR DESCRIPTION
## Summary
- add `compute_price_regime` helper to derive moving averages, standard deviation, bands and z-score for Buy Box prices
- show selected ASIN price regime in new Streamlit section with color-coded z-score
- cover price regime calculations with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ee2451a1c832086f308cc18b049c5