### PR TITLE
Add quality metrics computation and UI badges

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ from score import (
     SHIPPING_COSTS, VAT_RATES, normalize_locale,
     calculate_shipping_cost, calc_final_purchase_price,
     compute_profits, compute_opportunity_score, compute_price_regime,
-    compute_amazon_risk, parse_float, parse_int
+    compute_amazon_risk, compute_quality_metrics, parse_float, parse_int
 )
 
 # -----------------------
@@ -45,26 +45,43 @@ def _safe(x):
     except Exception:
         return "—"
 
-def _badge(value, suffix="€"):
-    """Badge XL colorato per profitti."""
+def _badge(value, suffix="€", cls_prefix="badge-profit", display_value=None):
+    """Badge XL colorato con colori customizzabili.
+
+    Parameters
+    ----------
+    value : float | int
+        Valore usato per determinare il colore (positivo=verde, negativo=rosso).
+    suffix : str, default "€"
+        Suffisso mostrato accanto al valore.
+    cls_prefix : str, default "badge-profit"
+        Prefisso delle classi CSS da utilizzare ("-pos", "-neg", "-neu").
+    display_value : float | int | None
+        Valore da visualizzare; se ``None`` viene usato ``value``.
+    """
+
+    if display_value is None:
+        display_value = value
+
     if value is None or (isinstance(value, float) and np.isnan(value)):
-        cls = "badge-profit-neu"; txt = "—"
+        cls = f"{cls_prefix}-neu"; txt = "—"
     else:
         try:
             v = float(value)
+            disp_val = float(display_value) if display_value is not None else v
             if suffix == "%":
-                disp = f"{round(v, 1)}{suffix}"
+                disp = f"{round(disp_val, 1)}{suffix}"
             else:
-                disp = f"{round(v, 2)}{suffix}"
+                disp = f"{round(disp_val, 2)}{suffix}"
             if v > 0.01:
-                cls = "badge-profit-pos"
+                cls = f"{cls_prefix}-pos"
             elif v < -0.01:
-                cls = "badge-profit-neg"
+                cls = f"{cls_prefix}-neg"
             else:
-                cls = "badge-profit-neu"
+                cls = f"{cls_prefix}-neu"
             txt = disp
         except Exception:
-            cls = "badge-profit-neu"; txt = "—"
+            cls = f"{cls_prefix}-neu"; txt = "—"
     return f'<span class="badge badge-xl {cls}">{txt}</span>'
 
 def _z_badge(z):
@@ -167,6 +184,9 @@ div[data-baseweb="select"] * { background: var(--card) !important; color: var(--
 .badge-profit-pos { background: rgba(0,196,106,.12); color: var(--good); }
 .badge-profit-neg { background: rgba(229,9,20,.12); color: var(--bad); }
 .badge-profit-neu { background: rgba(255,255,255,.1); color: var(--text); }
+.badge-quality-pos { background: rgba(0,196,106,.12); color: var(--good); }
+.badge-quality-neg { background: rgba(229,9,20,.12); color: var(--bad); }
+.badge-quality-neu { background: rgba(255,255,255,.1); color: var(--text); }
 .badge-flag-pos { background: rgba(0,196,106,.12); color: var(--good); }
 .badge-flag-neg { background: rgba(229,9,20,.12); color: var(--bad); }
 .badge-flag-neu { background: rgba(255,255,255,.1); color: var(--text); }
@@ -408,6 +428,7 @@ asin_sel = st.selectbox("Dettaglio ASIN", options=df_ess["ASIN"].unique())
 df_sel = dfp[dfp["ASIN"] == asin_sel]
 reg = compute_price_regime(df_sel, target_price_col)
 risk = compute_amazon_risk(df_sel)
+quality = compute_quality_metrics(df_sel)
 with st.expander("Price Regime"):
     st.write("Media 30g:", _safe(reg.get("BB_MA_30")))
     st.write("Media 90g:", _safe(reg.get("BB_MA_90")))
@@ -460,6 +481,34 @@ with st.expander("Amazon Risk & Events"):
     st.markdown(
         "Lightning Deals: Is Lowest: "
         + _flag_badge(risk.get("LD_IS_LOWEST"), txt_ok="No", txt_bad="Yes"),
+        unsafe_allow_html=True,
+    )
+
+with st.expander("Quality & Returns"):
+    ret = quality.get("Return Rate")
+    st.markdown(
+        "Return Rate: "
+        + _badge(-ret, "%", cls_prefix="badge-quality", display_value=ret),
+        unsafe_allow_html=True,
+    )
+    rating = quality.get("Reviews: Rating")
+    st.markdown(
+        "Reviews Rating: "
+        + _badge(
+            rating - 4.0,
+            "★",
+            cls_prefix="badge-quality",
+            display_value=rating,
+        ),
+        unsafe_allow_html=True,
+    )
+    st.markdown(
+        "Review Momentum: "
+        + _badge(
+            quality.get("ReviewsMomentum"),
+            "",
+            cls_prefix="badge-quality",
+        ),
         unsafe_allow_html=True,
     )
 

--- a/score.py
+++ b/score.py
@@ -226,6 +226,39 @@ def compute_amazon_risk(df: pd.DataFrame) -> pd.Series:
         }
     )
 
+
+def compute_quality_metrics(df: pd.DataFrame) -> pd.Series:
+    """Estrae metriche di qualità e ritorni da un singolo ASIN.
+
+    Parametri
+    ---------
+    df : pd.DataFrame
+        DataFrame filtrato su un singolo ASIN (una o più righe temporali).
+
+    Restituisce
+    ------------
+    pd.Series con:
+        - ``Return Rate`` (float)
+        - ``Reviews: Rating`` (float)
+        - ``ReviewsMomentum`` differenza tra rating count corrente e media 90g
+    """
+
+    row = df.iloc[0] if not df.empty else {}
+
+    ret_rate = parse_float(row.get("Return Rate"), default=np.nan)
+    rating = parse_float(row.get("Reviews: Rating"), default=np.nan)
+    rc = parse_int(row.get("Reviews: Rating Count"), default=np.nan)
+    rc90 = parse_int(row.get("Reviews: Rating Count - 90 days avg."), default=np.nan)
+    momentum = rc - rc90 if pd.notna(rc) and pd.notna(rc90) else np.nan
+
+    return pd.Series(
+        {
+            "Return Rate": ret_rate,
+            "Reviews: Rating": rating,
+            "ReviewsMomentum": momentum,
+        }
+    )
+
 # ---------------------------
 # Logica costo d’acquisto (invariata, default sconto 21%)
 # ---------------------------

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -10,6 +10,7 @@ from score import (
     compute_opportunity_score,
     aggregate_opportunities,
     compute_price_regime,
+    compute_quality_metrics,
 )
 
 
@@ -55,3 +56,18 @@ def test_compute_price_regime_basic():
     current = df["bb"].iloc[-1]
     z = (current - reg["BB_MA_365"]) / exp_std
     assert reg["BB_ZSCORE"] == pytest.approx(z)
+
+
+def test_compute_quality_metrics():
+    df = pd.DataFrame(
+        {
+            "Return Rate": ["5%"],
+            "Reviews: Rating": [4.2],
+            "Reviews: Rating Count": [120],
+            "Reviews: Rating Count - 90 days avg.": [100],
+        }
+    )
+    qm = compute_quality_metrics(df)
+    assert qm["Return Rate"] == 5.0
+    assert qm["Reviews: Rating"] == 4.2
+    assert qm["ReviewsMomentum"] == 20


### PR DESCRIPTION
## Summary
- add `compute_quality_metrics` to extract return rate, rating and review momentum
- display quality & returns metrics with color-coded badges and dark-theme styling
- include tests for new quality metrics logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ee6f06f288320b7019461c638da60