### PR TITLE
Add Streamlit e2e test

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ This project contains a Streamlit dashboard for analyzing product arbitrage oppo
    ```
 3. In the web interface, upload the origin marketplace file and one or more comparison files to begin analysis.
 
+### Manual end-to-end check
+
+To verify the dashboard manually:
+
+1. Start the application with `streamlit run app.py`.
+2. In the browser, choose an ASIN from the **Dettaglio ASIN** select box.
+3. Expand the panels **Price Regime**, **Competition Map**, **Amazon Risk & Events** and **Quality & Returns**.
+4. Ensure that the badges shown inside each panel display coherent values and styling.
+
 ## Configuration
 
 Provide your Keepa API key and optional password using environment variables or a local `secrets.toml` file. When using environment variables set `API_KEY` (and `PASSWORD` if needed) before running Streamlit:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ streamlit-extras>=0.3.0
 openpyxl>=3.0.0
 xlrd>=2.0.0
 streamlit-aggrid>=0.3.0
+playwright>=1.54
+pytest-playwright>=0.7

--- a/tests/test_app_e2e.py
+++ b/tests/test_app_e2e.py
@@ -1,0 +1,73 @@
+import subprocess
+import time
+import hashlib
+from pathlib import Path
+
+import requests
+from playwright.sync_api import sync_playwright
+
+
+def _wait_for_server(url: str, timeout: float = 60.0) -> None:
+    """Wait until Streamlit server at *url* responds."""
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            if requests.get(url).ok:
+                return
+        except Exception:
+            pass
+        time.sleep(1)
+    raise RuntimeError(f"Server at {url} did not become ready in {timeout} seconds")
+
+
+def test_streamlit_expand_and_df_ess(tmp_path):
+    # Ensure playwright browser is available
+    subprocess.run(["playwright", "install", "chromium"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    sample_file = Path(__file__).resolve().parents[1] / "sample_data" / "keepa_sample.xlsx"
+
+    proc = subprocess.Popen(
+        ["streamlit", "run", "app.py", "--server.headless=true", "--server.port=8501"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        _wait_for_server("http://localhost:8501/healthz")
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto("http://localhost:8501")
+            # upload required files
+            page.locator("input[type='file']").nth(0).set_input_files(str(sample_file))
+            page.locator("input[type='file']").nth(1).set_input_files(str(sample_file))
+            page.wait_for_selector("table")
+
+            html_before = page.locator("table").inner_html()
+            col_before = page.eval_on_selector("table tr", "el => el.children.length")
+
+            page.get_by_label("Dettaglio ASIN").click()
+            page.get_by_role("option").first.click()
+
+            exp_checks = {
+                "Price Regime": "Media 30g",
+                "Competition Map": "Total Offer Count",
+                "Amazon Risk & Events": "%Amazon Buy Box 30g",
+                "Quality & Returns": "Return Rate",
+            }
+            for label, snippet in exp_checks.items():
+                page.get_by_text(label, exact=True).click()
+                page.wait_for_selector(f"text={snippet}")
+
+            html_after = page.locator("table").inner_html()
+            col_after = page.eval_on_selector("table tr", "el => el.children.length")
+
+            assert col_before == col_after
+            assert hashlib.md5(html_before.encode()).hexdigest() == hashlib.md5(html_after.encode()).hexdigest()
+            browser.close()
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
## Summary
- add Playwright end-to-end test that launches the Streamlit app, uploads data, opens all four expanders and checks df_ess table remains unchanged
- document manual steps in README for expanding panels and verifying badges
- include Playwright dependencies in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ee8870fa8832097b95995fead3830