### PR TITLE
test: extend e2e coverage for presets

### DIFF
--- a/tests/test_app_e2e.py
+++ b/tests/test_app_e2e.py
@@ -21,8 +21,9 @@ def _wait_for_server(url: str, timeout: float = 60.0) -> None:
 
 
 def test_streamlit_expand_and_df_ess(tmp_path):
-    # Ensure playwright browser is available
+    # Ensure playwright browser and dependencies are available
     subprocess.run(["playwright", "install", "chromium"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.run(["playwright", "install-deps"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     sample_file = Path(__file__).resolve().parents[1] / "sample_data" / "keepa_sample.xlsx"
 
@@ -64,6 +65,86 @@ def test_streamlit_expand_and_df_ess(tmp_path):
 
             assert col_before == col_after
             assert hashlib.md5(html_before.encode()).hexdigest() == hashlib.md5(html_after.encode()).hexdigest()
+
+            # ensure uploaded data persists when switching presets
+            for preset in ["Flip veloce", "Margine alto", "Volume/Rotazione"]:
+                page.get_by_role("button", name=preset).click()
+                page.wait_for_selector("table")
+                assert page.locator("table").is_visible()
+            browser.close()
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_preset_save_and_load(tmp_path):
+    subprocess.run(["playwright", "install", "chromium"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.run(["playwright", "install-deps"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    sample_file = repo_root / "sample_data" / "keepa_sample.xlsx"
+    app_path = repo_root / "app.py"
+
+    proc = subprocess.Popen(
+        ["streamlit", "run", str(app_path), "--server.headless=true", "--server.port=8502"],
+        cwd=tmp_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        _wait_for_server("http://localhost:8502/healthz")
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto("http://localhost:8502")
+
+            # upload deterministic sample files
+            page.locator("input[type='file']").nth(0).set_input_files(str(sample_file))
+            page.locator("input[type='file']").nth(1).set_input_files(str(sample_file))
+
+            # change a couple of sliders and number inputs
+            profit_slider = page.get_by_label("Profit", exact=True)
+            profit_slider.evaluate(
+                "el => {el.value = 55; el.dispatchEvent(new Event('input', {bubbles: true})); el.dispatchEvent(new Event('change', {bubbles: true}));}"
+            )
+            epsilon_slider = page.get_by_label("Margine % (ε)", exact=True)
+            epsilon_slider.evaluate(
+                "el => {el.value = 4.4; el.dispatchEvent(new Event('input', {bubbles: true})); el.dispatchEvent(new Event('change', {bubbles: true}));}"
+            )
+            min_profit_input = page.get_by_label("Min Profit Amazon €", exact=True)
+            min_profit_input.fill("7")
+
+            saved_profit = float(profit_slider.get_attribute("aria-valuenow"))
+            saved_epsilon = float(epsilon_slider.get_attribute("aria-valuenow"))
+            saved_min_profit = float(min_profit_input.input_value())
+
+            page.get_by_label("Preset name").fill("e2e_tmp")
+            page.get_by_role("button", name="Save").click()
+
+            preset_file = tmp_path / ".streamlit" / "score_presets" / "e2e_tmp.json"
+            for _ in range(20):
+                if preset_file.exists():
+                    break
+                time.sleep(0.5)
+            else:
+                raise AssertionError("preset file was not created")
+
+            # new session to ensure defaults
+            page2 = browser.new_page()
+            page2.goto("http://localhost:8502")
+            page2.locator("input[type='file']").nth(0).set_input_files(str(sample_file))
+            page2.locator("input[type='file']").nth(1).set_input_files(str(sample_file))
+            page2.locator("input[type='file']").nth(2).set_input_files(str(preset_file))
+            page2.wait_for_timeout(1000)
+
+            assert float(page2.get_by_label("Profit", exact=True).get_attribute("aria-valuenow")) == saved_profit
+            assert float(page2.get_by_label("Margine % (ε)", exact=True).get_attribute("aria-valuenow")) == saved_epsilon
+            assert float(page2.get_by_label("Min Profit Amazon €", exact=True).input_value()) == saved_min_profit
+
             browser.close()
     finally:
         proc.terminate()


### PR DESCRIPTION
## Summary
- verify table persists after switching preset buttons
- add preset save/load round trip e2e test using sample data

## Testing
- `pytest tests/test_app_e2e.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ef6e8d4fc83209deb3e78c9183b7a