### PR TITLE
Add window signal to scoring workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,7 @@ from score import (
     recompute_row_profit,
     compute_amazon_risk,
     compute_quality_metrics,
+    compute_window_signal,
     parse_float,
     parse_int,
     DEFAULT_PENALTY_MAP,
@@ -685,6 +686,7 @@ dfp["OpportunityScore"] = compute_opportunity_score(
     penalty_threshold=penalty_threshold,
     penalty_suggested=penalty_suggested,
 )
+dfp["WindowSignal"] = compute_window_signal(dfp)
 
 # Apply manual site price edits from previous interactions
 if "dfp_editor" in st.session_state:

--- a/score.py
+++ b/score.py
@@ -263,6 +263,39 @@ def compute_quality_metrics(df: pd.DataFrame) -> pd.Series:
         }
     )
 
+
+def compute_window_signal(df: pd.DataFrame) -> pd.Series:
+    """Generate simple window signals based on risk and price regime data.
+
+    The input *df* is expected to already contain the normalised columns
+    returned by :func:`compute_amazon_risk` (``AMZ_OOS_90``,
+    ``AMZ_SHIP_DELAY``, ``LD_IS_LOWEST``) and by
+    :func:`compute_price_regime` (e.g. ``BB_ZSCORE``).  The rules are
+    intentionally minimal and prioritised as follows:
+
+    1. Shipping delay from Amazon → ``"DELAY"``
+    2. Lightning deal lowest price → ``"LIGHTNING"``
+    3. Amazon out of stock recently *and* positive z-score → ``"SELL"``
+
+    Rows not matching any condition result in an empty string.  The
+    function is vectorised and returns a ``Series`` aligned with ``df``.
+    """
+
+    if df is None or len(df) == 0:
+        return pd.Series([], dtype=object)
+
+    oos = _col(df, "AMZ_OOS_90", 0).map(lambda x: parse_int(x, default=0))
+    zscore = _col(df, "BB_ZSCORE", 0.0).map(lambda x: parse_float(x, default=0.0))
+    delay = _to_bool_series(_col(df, "AMZ_SHIP_DELAY", False))
+    lightning = _to_bool_series(_col(df, "LD_IS_LOWEST", False))
+
+    signal = pd.Series([""] * len(df), index=df.index, dtype=object)
+    signal[delay] = "DELAY"
+    signal[~delay & lightning] = "LIGHTNING"
+    sell_mask = (oos > 0) & (zscore > 0)
+    signal[~delay & ~lightning & sell_mask] = "SELL"
+    return signal
+
 # ---------------------------
 # Logica costo d’acquisto (invariata, default sconto 21%)
 # ---------------------------

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -11,6 +11,7 @@ from score import (
     aggregate_opportunities,
     compute_price_regime,
     compute_quality_metrics,
+    compute_window_signal,
 )
 
 
@@ -89,3 +90,33 @@ def test_compute_quality_metrics():
     assert qm["Return Rate"] == 5.0
     assert qm["Reviews: Rating"] == 4.2
     assert qm["ReviewsMomentum"] == 20
+
+
+def test_compute_window_signal_rules():
+    df = pd.DataFrame(
+        {
+            "AMZ_OOS_90": [1, 0, 0, 1],
+            "AMZ_SHIP_DELAY": [False, True, False, True],
+            "LD_IS_LOWEST": [False, False, True, True],
+            "BB_ZSCORE": [1.2, -0.5, 0.4, 0.3],
+        }
+    )
+    sig = compute_window_signal(df)
+    assert list(sig) == ["SELL", "DELAY", "LIGHTNING", "DELAY"]
+
+
+def test_compute_window_signal_integration_with_profits():
+    df = pd.DataFrame(
+        {
+            "Price_Base": [10.0],
+            "BuyBoxPrice": [15.0],
+            "Locale": ["IT"],
+            "AMZ_OOS_90": [2],
+            "AMZ_SHIP_DELAY": [0],
+            "LD_IS_LOWEST": [0],
+            "BB_ZSCORE": [1.1],
+        }
+    )
+    result = compute_profits(df, "Price_Base", "BuyBoxPrice")
+    result["WindowSignal"] = compute_window_signal(result)
+    assert result["WindowSignal"].iloc[0] == "SELL"


### PR DESCRIPTION
## Summary
- add `compute_window_signal` for SELL/DELAY/LIGHTNING signals based on Amazon risk and price regime metrics
- integrate window signal into Streamlit scoring workflow
- cover window signal logic with tests

## Testing
- `pytest tests/test_scores.py -q`
- `pytest -q` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689f32ab7d1c8320ae3e553f1fdb3f3c