### PR TITLE
feat: add window signal badges

### DIFF
--- a/app.py
+++ b/app.py
@@ -271,6 +271,21 @@ def _risk_badge(value, threshold, suffix="%"):
     return f'<span class="badge badge-xl {cls}">{txt}</span>'
 
 
+def _window_badge(signal: str | None) -> str:
+    """Badge per il segnale di finestra favorevole."""
+
+    mapping = {
+        "LIGHTNING": ("⚡", "badge-green"),
+        "DELAY": ("⏳", "badge-red"),
+        "SELL": ("OOS", "badge-green"),
+    }
+    if signal is None:
+        txt, cls = "—", "badge-gray"
+    else:
+        txt, cls = mapping.get(str(signal).upper(), ("—", "badge-gray"))
+    return f'<span class="badge badge-xl {cls}">{txt}</span>'
+
+
 def _missing_columns(df: pd.DataFrame, required: list[str]) -> list[str]:
     """Return a list of required columns that are absent from *df*."""
     return [c for c in required if c not in df.columns]
@@ -782,6 +797,9 @@ st.markdown(badges_html, unsafe_allow_html=True)
 
 df_view = df_view[mask]
 
+if st.toggle("Solo con finestra favorevole"):
+    df_view = df_view[df_view["WindowSignal"].notna() & (df_view["WindowSignal"] != "")]
+
 csv_view = df_view.to_csv(decimal=",", sep=";", index=False).encode("utf-8")
 st.download_button(
     "📥 Scarica CSV filtrato",
@@ -812,6 +830,7 @@ for c in [
     "Buy Box: % Amazon 90 days",
     "Return Rate",
     "OpportunityScore",
+    "WindowSignal",
 ]:
     if c in df_view.columns:
         cols_ess.append(c)
@@ -855,6 +874,7 @@ header = [
     "%Amazon 90d",
     "Return",
     "Score",
+    "Window",
 ]
 
 rows_html = []
@@ -889,6 +909,7 @@ for _, r in df_ess.iterrows():
         f"{_safe(r.get('Buy Box: % Amazon 90 days'))}",
         f"{_safe(r.get('Return Rate'))}",
         f"{_safe(r.get('OpportunityScore'))}",
+        _window_badge(r.get("WindowSignal")),
     ]
     rows_html.append(
         "<tr>"

--- a/style.css
+++ b/style.css
@@ -106,6 +106,29 @@
     display: inline-block;
 }
 
+/* Badge styles */
+.badge {
+    display: inline-block;
+    padding: 0.25rem 0.6rem;
+    border-radius: 10px;
+    font-weight: 600;
+}
+.badge-xl {
+    font-size: 0.95rem;
+}
+.badge-green {
+    background: rgba(0, 196, 106, 0.12);
+    color: #00c46a;
+}
+.badge-red {
+    background: rgba(229, 9, 20, 0.12);
+    color: #ff4d4d;
+}
+.badge-gray {
+    background: rgba(255, 255, 255, 0.1);
+    color: #a0a0a0;
+}
+
 /* Input e form controls */
 .stTextInput>div>div>input, 
 .stSelectbox>div>div>div, /* Attenzione: questo potrebbe essere troppo generico */


### PR DESCRIPTION
## Summary
- show window signal badges in results table
- allow filtering rows with favorable window
- style badges for window signal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f37591820832080a9ae51e0ab5766