### PR TITLE
feat: add multi-market selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -673,8 +673,18 @@ _validate_required_columns(df_orig, df_tgt, required_columns)
 # Left join: partiamo dall'origine (identità/Locale/peso), poi aggiungiamo target
 df = pd.merge(df_orig, df_tgt, on="ASIN", how="left", suffixes=("", " (tgt)"))
 
-# Imposta locale target (default IT)
-locale_target = "IT"
+# Selezione mercati target
+available_markets = ["IT", "DE", "FR", "ES"]
+selected_markets = st.multiselect(
+    "Mercati target",
+    available_markets,
+    default=st.session_state.get("locale_targets", ["IT", "DE"]),
+)
+if not (2 <= len(selected_markets) <= 4):
+    st.error("Selezionare da 2 a 4 mercati.")
+    st.stop()
+st.session_state["locale_targets"] = selected_markets
+locale_target = selected_markets[0]
 
 # Calcola profitti (logica IVA/sconto invariata; default sconto = sidebar)
 dfp = compute_profits(


### PR DESCRIPTION
## Summary
- allow choosing target markets via Streamlit multiselect
- validate that 2-4 markets are selected and store selection in session state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f5a6cd9d483209f57ec9aca99424d