### PR TITLE
Cache heavy computations in data loading and profit calculation

### DIFF
--- a/loaders.py
+++ b/loaders.py
@@ -4,10 +4,23 @@
 # (La logica di calcolo resta invariata; qui solo utilità.)
 # --------------------------------------------
 from __future__ import annotations
+import pathlib
 import pandas as pd
 import numpy as np
 from io import BytesIO
 from score import parse_float, parse_int, parse_weight
+
+try:
+    import streamlit as st
+except Exception:  # pragma: no cover - streamlit not available
+    class _StreamlitCacheStub:
+        def cache_data(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    st = _StreamlitCacheStub()
 
 
 def _to_bool_series(s: pd.Series) -> pd.Series:
@@ -48,6 +61,36 @@ def _to_bool_series(s: pd.Series) -> pd.Series:
     return s.map(_convert)
 
 def load_data(file, schema: dict[str, str] | None = None) -> pd.DataFrame:
+    """Carica un file tabellare applicando caching sul contenuto.
+
+    Il parametro ``file`` può essere un percorso, un oggetto ``UploadedFile`` di
+    Streamlit o qualunque file-like.  L'implementazione converte il contenuto in
+    ``bytes`` così da consentire a :func:`st.cache_data` di evitare ricarichi
+    inutili quando lo stesso file viene letto più volte.
+    """
+
+    if isinstance(file, (str, pathlib.Path)):
+        path = pathlib.Path(file)
+        data = path.read_bytes()
+        name = path.name
+    else:
+        try:
+            data = file.getvalue()
+        except Exception:
+            data = file.read()
+        name = getattr(file, "name", "")
+
+    return _load_data_cached(data, name, schema)
+
+
+@st.cache_data(show_spinner=False)
+def _load_data_cached(data: bytes, name: str, schema: dict[str, str] | None = None) -> pd.DataFrame:
+    file = BytesIO(data)
+    file.name = name
+    return _load_data_impl(file, schema)
+
+
+def _load_data_impl(file, schema: dict[str, str] | None = None) -> pd.DataFrame:
     name = getattr(file, "name", "").lower()
     if name.endswith(".xlsx") or name.endswith(".xls"):
         df = pd.read_excel(file)

--- a/score.py
+++ b/score.py
@@ -9,6 +9,18 @@ import math
 import pandas as pd
 import numpy as np
 
+try:
+    import streamlit as st
+except Exception:  # pragma: no cover - fallback when streamlit not installed
+    class _StreamlitCacheStub:
+        def cache_data(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    st = _StreamlitCacheStub()
+
 
 def parse_float(x, default=None):
     try:
@@ -501,6 +513,10 @@ def compute_best_market(df: pd.DataFrame) -> pd.Series:
 def compute_profits_multi(df: pd.DataFrame, targets: dict[str, str]) -> pd.DataFrame:
     """Calcola profitti e punteggio opportunità per più mercati.
 
+    La funzione funge da wrapper per una versione *cached* interna in modo che
+    ripetute invocazioni con lo stesso ``DataFrame`` e la stessa lista di
+    mercati riutilizzino i risultati precedenti.
+
     Parameters
     ----------
     df:
@@ -518,6 +534,25 @@ def compute_profits_multi(df: pd.DataFrame, targets: dict[str, str]) -> pd.DataF
         ``_<locale>``.
     """
 
+    markets = tuple(sorted(targets.keys()))
+    target_cols = tuple(targets[m] for m in markets)
+    return _compute_profits_multi_cached(df, markets, target_cols)
+
+
+@st.cache_data(show_spinner=False)
+def _compute_profits_multi_cached(
+    df: pd.DataFrame,
+    markets: tuple[str, ...],
+    target_cols: tuple[str, ...],
+) -> pd.DataFrame:
+    """Implementazione cache-aware di :func:`compute_profits_multi`.
+
+    L'output dipende dal ``DataFrame`` di input e dalla lista ordinata dei
+    mercati, usata come chiave di caching insieme ai nomi delle colonne
+    target.
+    """
+
+    targets = dict(zip(markets, target_cols))
     result = df.copy()
     base_cols = set(result.columns)
 


### PR DESCRIPTION
## Summary
- Add Streamlit `cache_data` wrappers for expensive helper functions
- Cache file loading in `load_data` to avoid repeated disk reads
- Provide cached multi-market profit computation keyed by input frame and markets

## Testing
- `pytest tests/test_scores.py tests/test_loaders.py -q`
- `python - <<'PY'
import pandas as pd, numpy as np, time
from score import compute_profits_multi
n=1000
markets=['IT','DE','FR','ES']
prices = np.random.rand(n)*10+5
df=pd.DataFrame({'Price_Base':prices})
for m in markets:
    df[f'BuyBoxPrice_{m}']=prices*1.5
targets={m:f'BuyBoxPrice_{m}' for m in markets}
start=time.time(); compute_profits_multi(df, targets); print('elapsed', time.time()-start)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689f6a6660a083209c7d25f40caa4be5