### PR TITLE
Fix row generation loop indentation

### DIFF
--- a/app.py
+++ b/app.py
@@ -938,13 +938,13 @@ for _, r in df_ess.iterrows():
     if pd.isna(peso):
         peso = r.get("Item: Weight (g)", np.nan)
 
-row = [
-    r.get("ASIN", ""),
-    r.get("Title", ""),
-    r.get("Brand", ""),
-    r.get("Locale", ""),
-    r.get("Best Market", ""),
-    f"{_safe(r.get('Orig Price'))}",
+    row = [
+        r.get("ASIN", ""),
+        r.get("Title", ""),
+        r.get("Brand", ""),
+        r.get("Locale", ""),
+        r.get("Best Market", ""),
+        f"{_safe(r.get('Orig Price'))}",
         f"{_safe(r.get('PurchaseNetExVAT'))}",
         f"{_safe(peso)}",
         f"{_safe(r.get('BB Target'))}",


### PR DESCRIPTION
## Summary
- Ensure table rows are built inside the iteration over `df_ess`.
- Append each row within the loop so HTML table renders correctly.

## Testing
- `pytest` *(fails: TimeoutError in test_streamlit_expand_and_df_ess)*

------
https://chatgpt.com/codex/tasks/task_e_689f877f79c48320a136260883d75e09