### PR TITLE
Handle missing Buy Box column for Prezzo Sito

### DIFF
--- a/app.py
+++ b/app.py
@@ -721,7 +721,11 @@ main_cols = [c for c in dfp.columns if c.endswith(suffix_main)]
 dfp = dfp.rename(columns={c: c[: -len(suffix_main)] for c in main_cols})
 
 # Colonna modificabile manualmente con fallback al Buy Box corrente
-dfp["Prezzo Sito"] = dfp["SitePriceGross"].fillna(dfp.get("Buy Box 🚚: Current"))
+fallback = dfp.get(
+    "Buy Box 🚚: Current",
+    pd.Series(index=dfp.index, dtype=dfp["SitePriceGross"].dtype),
+)
+dfp["Prezzo Sito"] = dfp["SitePriceGross"].fillna(fallback)
 
 dfp["WindowSignal"] = compute_window_signal(dfp)
 

--- a/tests/test_prezzo_sito_fallback.py
+++ b/tests/test_prezzo_sito_fallback.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+
+def test_prezzo_sito_fallback_missing_column():
+    dfp = pd.DataFrame({"SitePriceGross": [1.0, None]}, index=[0, 1])
+    fallback = dfp.get(
+        "Buy Box 🚚: Current",
+        pd.Series(index=dfp.index, dtype=dfp["SitePriceGross"].dtype),
+    )
+    assert fallback is not None
+    assert fallback.index.equals(dfp.index)
+
+    dfp["Prezzo Sito"] = dfp["SitePriceGross"].fillna(fallback)
+
+    assert pd.isna(dfp.loc[1, "Prezzo Sito"])


### PR DESCRIPTION
## Summary
- Ensure `Prezzo Sito` uses a proper Series fallback when "Buy Box 🚚: Current" column is absent
- Add regression test confirming the fallback covers all rows without passing `None` to `fillna`

## Testing
- `pytest` *(fails: stuck on tests/test_app_e2e.py)*
- `pytest tests/test_prezzo_sito_fallback.py tests/test_loaders.py tests/test_purchase_price.py tests/test_scores.py tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8c8be95c832080a640e8952dfdc3