### PR TITLE
Avoid pd.NA in site price fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -721,10 +721,10 @@ main_cols = [c for c in dfp.columns if c.endswith(suffix_main)]
 dfp = dfp.rename(columns={c: c[: -len(suffix_main)] for c in main_cols})
 
 # Colonna modificabile manualmente con fallback al Buy Box corrente
-fallback = dfp.get(
-    "Buy Box 🚚: Current",
-    pd.Series(index=dfp.index, dtype=dfp["SitePriceGross"].dtype),
-)
+# Use a float fallback to avoid passing pd.NA to fillna when SitePriceGross
+# has a nullable integer dtype (Int64). pd.NA cannot be used directly with
+# Series.fillna, so default to a Series of ``np.nan`` values instead.
+fallback = dfp.get("Buy Box 🚚: Current", pd.Series(np.nan, index=dfp.index))
 dfp["Prezzo Sito"] = dfp["SitePriceGross"].fillna(fallback)
 
 dfp["WindowSignal"] = compute_window_signal(dfp)

--- a/tests/test_prezzo_sito_fallback.py
+++ b/tests/test_prezzo_sito_fallback.py
@@ -1,14 +1,24 @@
+import numpy as np
 import pandas as pd
 
 
 def test_prezzo_sito_fallback_missing_column():
     dfp = pd.DataFrame({"SitePriceGross": [1.0, None]}, index=[0, 1])
-    fallback = dfp.get(
-        "Buy Box 🚚: Current",
-        pd.Series(index=dfp.index, dtype=dfp["SitePriceGross"].dtype),
-    )
+    fallback = dfp.get("Buy Box 🚚: Current", pd.Series(np.nan, index=dfp.index))
     assert fallback is not None
     assert fallback.index.equals(dfp.index)
+
+    dfp["Prezzo Sito"] = dfp["SitePriceGross"].fillna(fallback)
+
+    assert pd.isna(dfp.loc[1, "Prezzo Sito"])
+
+
+def test_prezzo_sito_fallback_int64_dtype():
+    dfp = pd.DataFrame(
+        {"SitePriceGross": pd.Series([1, pd.NA], dtype="Int64")},
+        index=[0, 1],
+    )
+    fallback = dfp.get("Buy Box 🚚: Current", pd.Series(np.nan, index=dfp.index))
 
     dfp["Prezzo Sito"] = dfp["SitePriceGross"].fillna(fallback)
 


### PR DESCRIPTION
## Summary
- use float fallback when `Buy Box 🚚: Current` column is missing so no `pd.NA` reaches `fillna`
- test site price fallback with Int64 `SitePriceGross`

## Testing
- `pytest tests/test_prezzo_sito_fallback.py -q`
- `pytest -q` *(fails: Page.wait_for_selector Timeout 30000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_689f9a77da9883209e176459c9d41c7b